### PR TITLE
ERP unit tests

### DIFF
--- a/backend/spring-server/src/test/java/io/swagger/api/erp/ArticlesApiControllerTest.java
+++ b/backend/spring-server/src/test/java/io/swagger/api/erp/ArticlesApiControllerTest.java
@@ -1,0 +1,91 @@
+package io.swagger.api.erp;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.restassured.RestAssured;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+
+public class ArticlesApiControllerTest {
+	String token = "Bearer 44bafa20-7861-4b65-b7a1-fdc3f258c6a9";
+	RequestSpecification httpRequest = RestAssured.given().
+						contentType("application/json").
+						headers("accept", "application/json",
+								"Authorization", token);
+
+	/*
+	 * Nie może pobrac unitID, chocia GET unit smiga az milo
+	 */
+	@Test
+	public void testCreateArticle() {
+		/*
+		 * Najpierw trzeba utworzyc unit i podac jego id
+		 */
+		String newObj = "{ \"id\": 1, \"availability\": 1, \"unitId\": 5, \"unitPrice\": 55, \"weight\": 1}";
+		Response response = httpRequest.
+							and().
+							body(newObj).
+							when().
+							post("http://localhost:8080/api/erp/articles");
+		//JsonPath jsonPath = new JsonPath(response.getBody().asString());
+
+		System.out.println("article ID -> " + response.asString());
+		int id = response.getStatusCode();
+		assertEquals(id,200);
+	}
+
+	@Test
+	public void testDeleteArticle() {
+		httpRequest.
+		when().
+		delete("http://localhost:8080/api/erp/articles/1");
+
+	Response response = httpRequest.
+						when().
+						get("http://localhost:8080/api/erp/articles/1");
+
+	JsonPath jsonPath = new JsonPath(response.getBody().asString());
+	String msg = jsonPath.getString("message");
+	assertEquals(msg,"Model not found");
+	}
+
+	@Test
+	public void testGetArticle() {
+		Response response = httpRequest.when().get("http://localhost:8080/api/erp/articles/1");
+		JsonPath jsonPath = new JsonPath(response.getBody().asString());
+		int resID = jsonPath.getInt("id");
+		assertEquals(resID,1);
+	}
+
+	@Test
+	public void testGetArticles() {
+		Response response = httpRequest.get("http://localhost:8080/api/erp/articles");
+		int statusCode = response.getStatusCode();
+		assertEquals(statusCode , 200 );
+	}
+
+	@Test
+	public void testUpdateArticle() {
+		String myJson = "{ \"id\": 1, \"availability\": 2, \"unitId\": 5, \"unitPrice\": 69, \"weight\": 96}";
+
+		httpRequest.
+				body(myJson).
+				when().
+				put("http://localhost:8080/api/erp/articles/1");
+
+		JsonPath jsonPath = new JsonPath(
+				httpRequest.
+				when().
+				get("http://localhost:8080/api/erp/articles/1").
+				getBody().
+				asString()
+				);
+		int resId = jsonPath.getInt("availability");
+		//System.out.println("name: " + resDesc);
+		assertEquals(resId,2);
+	}
+
+}

--- a/backend/spring-server/src/test/java/io/swagger/api/erp/DeliveryCostsApiControllerTest.java
+++ b/backend/spring-server/src/test/java/io/swagger/api/erp/DeliveryCostsApiControllerTest.java
@@ -1,0 +1,88 @@
+package io.swagger.api.erp;
+
+import static org.junit.Assert.*;
+
+import org.hamcrest.core.Is;
+import org.junit.Test;
+import io.restassured.RestAssured;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+
+public class DeliveryCostsApiControllerTest {
+	String token = "Bearer 44bafa20-7861-4b65-b7a1-fdc3f258c6a9";
+	RequestSpecification httpRequest = RestAssured.given().
+										contentType("application/json").
+										headers("accept", "application/json",
+												"Authorization", token);
+
+	@Test
+	public void testCreateDeliveryCost() {
+		String json = "{ \"id\": 1, \"weightFrom\": 0, \"weightTo\": 0, \"price\": 0}";
+		Response response = httpRequest.
+								and().
+								body(json).
+								when().
+								post("http://localhost:8080/api/erp/deliveryCosts");
+		int check = response.getStatusCode();
+		System.out.println("Delivery Costs id -> " + response.asString()); // 9
+		assertEquals(check,200);
+	}
+
+	@Test
+	public void testDeleteDeliveryCost() {
+		httpRequest.
+		when().
+		delete("http://localhost:8080/api/erp/deliveryCosts/9");
+
+	Response response = httpRequest.
+						when().
+						get("http://localhost:8080/api/erp/deliveryCosts/9");
+
+	JsonPath jsonPath = new JsonPath(response.getBody().asString());
+	String msg = jsonPath.getString("message");
+	assertEquals(msg,"Model not found");
+	}
+
+	@Test
+	public void testGetDeliveryCost() {
+		Response response = httpRequest.
+				when().
+				get("http://localhost:8080/api/erp/deliveryCosts/9");
+		JsonPath jsonPath = new JsonPath(response.getBody().asString());
+		int resID = jsonPath.getInt("id");
+		assertEquals(resID,9);
+	}
+
+	@Test
+	public void testGetDeliveryCosts() {
+		Response response = httpRequest.
+				get("http://localhost:8080/api/erp/deliveryCosts");
+		int statusCode = response.getStatusCode();
+		assertEquals(statusCode , 200 );
+	}
+
+	/*
+	 * Kod 500 przy PUT
+	 */
+	@Test
+	public void testUpdateDeliveryCost() {
+		String myJson = "{ \"id\": 14, \"weightFrom\": 5.0, \"weightTo\": 10.0, \"price\": 1.00}";
+
+		httpRequest.
+				body(myJson).
+				when().
+				put("http://localhost:8080/api/erp/deliveryCosts/9");
+
+		JsonPath jsonPath = new JsonPath(
+				httpRequest.
+				when().
+				get("http://localhost:8080/api/erp/deliveryCosts/9").
+				getBody().
+				asString()
+				);
+		int res = jsonPath.getInt("id");
+		assertEquals(res,14);
+	}
+
+}

--- a/backend/spring-server/src/test/java/io/swagger/api/erp/OrderedArticlesApiControllerTest.java
+++ b/backend/spring-server/src/test/java/io/swagger/api/erp/OrderedArticlesApiControllerTest.java
@@ -1,0 +1,99 @@
+package io.swagger.api.erp;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import io.restassured.RestAssured;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+
+public class OrderedArticlesApiControllerTest {
+	String token = "Bearer 44bafa20-7861-4b65-b7a1-fdc3f258c6a9";
+	RequestSpecification httpRequest = RestAssured.given().
+										contentType("application/json").
+										headers("accept", "application/json",
+												"Authorization", token);
+	@Test
+	public void testCreateOrderedArticle() {
+		String json = "{ \"id\": 0, \"articleId\": 1, \"orderId\": 1, \"description\": \"string\", \"amount\": 0, \"unitPrice\": 0, \"netPrice\": 0, \"weight\": 0}";
+		Response response = httpRequest.
+								and().
+								body(json).
+								when().
+								post("http://localhost:8080/api/erp/orders/{orderId}/articles");
+		int check = response.getStatusCode();
+		System.out.println("Order ID -> " + response.asString());
+		assertEquals(check,200);
+	}
+
+	@Test
+	public void testDeleteOrderedArticle() {
+		httpRequest.
+		when().
+		delete("http://localhost:8080/api/erp/orders/{orderId}/articles/{orderedArticleId}");
+
+	Response response = httpRequest.
+						when().
+						get("http://localhost:8080/api/erp/orders/{orderId}/articles/{orderedArticleId}");
+
+	JsonPath jsonPath = new JsonPath(response.getBody().asString());
+	String msg = jsonPath.getString("message");
+	assertEquals(msg,"Model not found");
+	}
+
+	@Test
+	public void testGetOrderedArticle() {
+		Response response = httpRequest.
+				when().
+				get("http://localhost:8080/api/erp/orders/{orderId}/articles/{orderedArticleId}");
+		JsonPath jsonPath = new JsonPath(response.getBody().asString());
+		int resID = jsonPath.getInt("id");
+		assertEquals(resID, {orderedArticleId} );
+	}
+
+	@Test
+	public void testGetOrderedArticleNetPrice() {
+		Response response = httpRequest.
+				when().
+				get("http://localhost:8080/api/erp/orders/{orderId}/articles/{orderedArticleId}/netPrice");
+
+		int check = response.getStatusCode();
+		System.out.println("Net Price -> " + response.asString());
+		assertEquals(check,200);
+	}
+
+	@Test
+	public void testGetOrderedArticleWeight() {
+		fail("Not yet implemented");
+	}
+
+	@Test
+	public void testGetOrderedArticles() {
+		Response response = httpRequest.
+				get("http://localhost:8080/api/erp/orders/{orderId}/articles");
+		int statusCode = response.getStatusCode();
+		assertEquals(statusCode , 200 );
+	}
+
+	@Test
+	public void testUpdateOrderedArticle() {
+		String myJson = "{ \"id\": 0, \"articleId\": {articleID}, \"orderId\": {orderID}, \"description\": \"update\", \"amount\": 0, \"unitPrice\": 0, \"netPrice\": 0, \"weight\": 0}";
+
+		httpRequest.
+				body(myJson).
+				when().
+				put("http://localhost:8080/api/erp/orders/{orderId}/articles/{orderedArticleId}");
+
+		JsonPath jsonPath = new JsonPath(
+				httpRequest.
+				when().
+				get("http://localhost:8080/api/erp/orders/{orderId}/articles/{orderedArticleId}").
+				getBody().
+				asString()
+				);
+		String res = jsonPath.getString("description");
+		assertEquals(res,"update");
+	}
+
+}

--- a/backend/spring-server/src/test/java/io/swagger/api/erp/OrdersApiControllerTest.java
+++ b/backend/spring-server/src/test/java/io/swagger/api/erp/OrdersApiControllerTest.java
@@ -1,0 +1,104 @@
+package io.swagger.api.erp;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.RestAssured;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+
+
+public class OrdersApiControllerTest {
+	String token = "Bearer 44bafa20-7861-4b65-b7a1-fdc3f258c6a9";
+	RequestSpecification httpRequest = RestAssured.given().
+										contentType("application/json").
+										headers("accept", "application/json",
+												"Authorization", token);
+
+	@Test
+	public void testCreateOrder() {
+
+		String json = "{ \"order\": { \"id\": 0, \"orderNumber\": \"string\", \"orderDate\": \"string\", \"realizationDate\": \"string\", \"realizationDeadline\": \"string\", \"employeeId\": 0, \"clientId\": 0, \"conditions\": \"string\", \"comments\": \"string\", \"advance\": 0, \"vat\": 0, \"state\": \"string\", \"deliveryCost\": 0, \"deliveryAddress\": \"string\", \"isSigned\": false, \"isPaid\": \"string\", \"isDone\": false }}";
+		Response response = httpRequest.
+								and().
+								body(json).
+								when().
+								post("http://localhost:8080/api/erp/orders");
+		int check = response.getStatusCode();
+		System.out.println("Order ID -> " + response.asString());
+		assertEquals(check,200);
+	}
+
+	@Test
+	public void testDeleteOrder() {
+		httpRequest.
+		when().
+		delete("http://localhost:8080/api/erp/orders/1");
+
+	Response response = httpRequest.
+						when().
+						get("http://localhost:8080/api/erp/orders/1");
+
+	JsonPath jsonPath = new JsonPath(response.getBody().asString());
+	String msg = jsonPath.getString("message");
+	assertEquals(msg,"Model not found");
+	}
+
+	@Test
+	public void testGetOrder() {
+		Response response = httpRequest.when().get("http://localhost:8080/api/erp/orders/1");
+		JsonPath jsonPath = new JsonPath(response.getBody().asString());
+		int resID = jsonPath.getInt("id");
+		assertEquals(resID,1);
+	}
+
+	@Test
+	public void testGetOrderDeliveryCosts() {
+		Response response = httpRequest.when().get("http://localhost:8080/api/erp/orders/1/deliveryCosts");
+
+		int check = response.getStatusCode();
+		System.out.println("Delivery Costs -> " + response.asString());
+		assertEquals(check,200);
+	}
+
+	@Test
+	public void testGetOrderNetPrice() {
+		Response response = httpRequest.when().get("http://localhost:8080/api/erp/orders/1/netPrice");
+
+		int check = response.getStatusCode();
+		System.out.println("Net Price -> " + response.asString());
+		assertEquals(check,200);
+	}
+
+	@Test
+	public void testGetOrders() {
+		Response response = httpRequest.get("http://localhost:8080/api/erp/orders");
+		int statusCode = response.getStatusCode();
+		assertEquals(statusCode , 200 );
+	}
+
+	@Test
+	public void testUpdateOrder() {
+		String myJson = "{ \"order\": { \"id\": 1, \"orderNumber\": \"string\", \"orderDate\": \"string\", \"realizationDate\": \"string\", \"realizationDeadline\": \"string\", \"employeeId\": 0, \"clientId\": 0, \"conditions\": \"update\", \"comments\": \"string\", \"advance\": 0, \"vat\": 0, \"state\": \"string\", \"deliveryCost\": 0, \"deliveryAddress\": \"string\", \"isSigned\": false, \"isPaid\": \"string\", \"isDone\": false }}";
+
+		httpRequest.
+				body(myJson).
+				when().
+				put("http://localhost:8080/api/erp/orders/1");
+
+		JsonPath jsonPath = new JsonPath(
+				httpRequest.
+				when().
+				get("http://localhost:8080/api/erp/orders/1").
+				getBody().
+				asString()
+				);
+		String res = jsonPath.getString("conditions");
+		assertEquals(res,"update");
+	}
+
+}

--- a/backend/spring-server/src/test/java/io/swagger/api/erp/ProformasApiControllerTest.java
+++ b/backend/spring-server/src/test/java/io/swagger/api/erp/ProformasApiControllerTest.java
@@ -1,0 +1,84 @@
+package io.swagger.api.erp;
+
+import static org.junit.Assert.*;
+import io.restassured.RestAssured;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+
+import org.junit.Test;
+
+public class ProformasApiControllerTest {
+	String token = "Bearer 44bafa20-7861-4b65-b7a1-fdc3f258c6a9";
+	RequestSpecification httpRequest = RestAssured.given().
+										contentType("application/json").
+										headers("accept", "application/json",
+												"Authorization", token);
+
+	@Test
+	public void testCreateProforma() {
+		String json = "{ \"id\": 0, \"proformaNumber\": \"string\", \"orderId\": {orderID}, \"issueDate\": \"string\", \"saleDate\": \"string\", \"paymentDate\": \"string\", \"paymentMethod\": \"string\"}";
+		Response response = httpRequest.
+								and().
+								body(json).
+								when().
+								post("http://localhost:8080/api/erp/proformas");
+		int check = response.getStatusCode();
+		System.out.println("Proforma ID -> " + response.asString());
+		assertEquals(check,200);
+	}
+
+	@Test
+	public void testDeleteProforma() {
+		httpRequest.
+		when().
+		delete("http://localhost:8080/api/erp/proformas");
+
+	Response response = httpRequest.
+						when().
+						get("http://localhost:8080/api/erp/proformas/{proformaID}");
+
+	JsonPath jsonPath = new JsonPath(response.getBody().asString());
+	String msg = jsonPath.getString("message");
+	assertEquals(msg,"Model not found");
+	}
+
+	@Test
+	public void testGetProforma() {
+		Response response = httpRequest.
+				when().
+				get("http://localhost:8080/api/erp/proformas/{proformaID}");
+		JsonPath jsonPath = new JsonPath(response.getBody().asString());
+		int resID = jsonPath.getInt("id");
+		assertEquals(resID, {proformaID} );
+	}
+
+	@Test
+	public void testGetProformas() {
+		Response response = httpRequest.
+				get("http://localhost:8080/api/erp/proformas");
+		int statusCode = response.getStatusCode();
+		assertEquals(statusCode , 200 );
+	}
+
+	@Test
+	public void testUpdateProforma() {
+		String myJson = "{ \"id\": 0, \"proformaNumber\": \"update\", \"orderId\": {orderID}, \"issueDate\": \"string\", \"saleDate\": \"string\", \"paymentDate\": \"string\", \"paymentMethod\": \"string\"}";
+
+		httpRequest.
+				body(myJson).
+				when().
+				put("http://localhost:8080/api/erp/proformas/{proformaId}");
+
+		JsonPath jsonPath = new JsonPath(
+				httpRequest.
+				when().
+				get("http://localhost:8080/api/erp/proformas/{proformaId}").
+				getBody().
+				asString()
+				);
+		String res = jsonPath.getString("proformaNumber");
+		assertEquals(res,"update");
+	}
+
+}


### PR DESCRIPTION
Niektóre testy są "niekompletne", tzn. nie można stworzyć obiektów, od których zależą inne  (np. Client, OrderedArticles, Proformas), więc w requestach jest, zamiast konkretnych id, np. {orderID}.